### PR TITLE
test

### DIFF
--- a/components/AppErrors.php
+++ b/components/AppErrors.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace app\components;
+
+class AppErrors
+{
+    public const INVALID_REQUEST = 'invalid_request';
+    public const SYSTEM_FAULT = 'system_fault';
+
+    public static function getText($state): string
+    {
+        switch ($state) {
+            case self::INVALID_REQUEST:
+                $message = 'Неверные параметры запроса';
+                break;
+            case self::SYSTEM_FAULT:
+            default:
+                $message = 'Непредвиденная ошибка';
+        };
+
+        return $message;
+    }
+
+    public static function getStatusCode($state): int
+    {
+        switch ($state) {
+            case self::INVALID_REQUEST:
+                $code = 400;
+                break;
+            case self::SYSTEM_FAULT:
+            default:
+                $code = 500;
+        };
+
+        return $code;
+    }
+}

--- a/components/AppException.php
+++ b/components/AppException.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace app\components;
+
+use Exception;
+use Throwable;
+
+class AppException extends Exception
+{
+    public function __construct($message = "", $code = 0, Throwable $previous = null) {
+        if($message && !$code) {
+            $code = AppErrors::getStatusCode($message);
+        }
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/components/prices/DummyPrices.php
+++ b/components/prices/DummyPrices.php
@@ -1,0 +1,47 @@
+<?php
+namespace app\components\prices;
+
+use app\components\AppException;
+use app\components\AppErrors;
+use dummy\Prices as DummyPricesProvider;
+use Yii;
+use yii\caching\CacheInterface;
+
+class DummyPrices implements Prices
+{
+    private DummyPricesProvider $provider;
+
+    protected ?CacheInterface $cache;
+
+    public function __construct()
+    {
+        $this->cache = Yii::$app->pcache ?? null;
+        $this->provider = new DummyPricesProvider();
+    }
+
+    /**
+     * @param int $id
+     * @return float
+     * @throws AppException
+     */
+    public function getPrice(int $id): float
+    {
+        try {
+            if($this->cache) {
+
+                $price = $this->cache->get($id);
+                if($price === false) {
+                    $price = $this->provider->getPrice($id);
+                    $this->cache->set($id, $price);
+                }
+            } else {
+                $price = $this->provider->getPrice($id);
+            }
+
+            return $price;
+
+        } catch(\Exception $ex) {
+            throw new AppException(AppErrors::SYSTEM_FAULT);
+        }
+    }
+}

--- a/components/prices/Prices.php
+++ b/components/prices/Prices.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace app\components\prices;
+
+interface Prices
+{
+    public function getPrice(int $id): float;
+}

--- a/config/web.php
+++ b/config/web.php
@@ -20,6 +20,10 @@ $config = [
         'cache' => [
             'class' => 'yii\caching\FileCache',
         ],
+        'pcache' => [
+            'class' => 'yii\caching\FileCache',
+            'keyPrefix' => 'pcache',
+        ],
         'errorHandler' => [
             'errorAction' => 'site/error',
         ],

--- a/controllers/BasketController.php
+++ b/controllers/BasketController.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace app\controllers;
+
+use Yii;
+use yii\helpers\Json;
+use yii\web\Controller;
+use yii\web\Response;
+use app\components\{
+    AppException,
+    prices\DummyPrices,
+    AppErrors
+};
+
+class BasketController extends Controller
+{
+
+    public function actionCalculate(): array
+    {
+        Yii::$app->response->format = Response::FORMAT_JSON;
+        $response = [
+            'errorCode' => null,
+            'errorText' => null,
+            'data' => []
+        ];
+
+        try {
+            $requestData = Json::decode(Yii::$app->request->rawBody);
+            if(empty($requestData['data']['basket'])) {
+                throw new AppException(AppErrors::INVALID_REQUEST);
+            }
+
+            $basketObj = $requestData['data']['basket'];
+
+            if(!empty($basketObj['items'])) {
+
+                $dummyPrices = new DummyPrices();
+                $basketObj['total'] = 0;
+                foreach($basketObj['items'] as &$item) {
+                    $item = array_map('intval', $item);
+
+                    $basketObj['total'] += $item['price'] = round($item['count'] * $dummyPrices->getPrice($item['id']), 2);
+                }
+                $response['data']['basket'] = $basketObj;
+            }
+        } catch(AppException $e) {
+            $response['errorCode'] = ($error = $e->getMessage());
+            $response['errorText'] = AppErrors::getText($error);
+
+            Yii::$app->response->statusCode = $e->getCode();
+        } catch(\Exception $e) {
+            $response['errorCode'] = ($error = AppErrors::SYSTEM_FAULT);
+            $response['errorText'] = AppErrors::getText($error);
+
+            Yii::$app->response->statusCode = AppErrors::getStatusCode($error);
+        }
+
+        return $response;
+    }
+}

--- a/vendor/dummy/Prices.php
+++ b/vendor/dummy/Prices.php
@@ -1,0 +1,14 @@
+<?php
+namespace dummy;
+
+class Prices
+{
+    /**
+     * @param int $id
+     * @return float
+     */
+    public function getPrice(int $id): float
+    {
+        return round(rand(100, 1000) / 33.33, 2);
+    }
+}


### PR DESCRIPTION
Всё что делал в этом пул реквесте.

Добавил обработку ошибок [components/AppErrors.php](https://github.com/ktigay/tanuki-test/pull/1/files#diff-16843e10770de30638125403a8dc23a1052ab59f91e0099a5fe322f5e19eb9cc), [components/AppException.php](https://github.com/ktigay/tanuki-test/pull/1/files#diff-9af3ae960043e603ac1bb29e5452f03f930e4601fe5fdd0989fd282c2308c441).
Для получения данных добавил интерфейс [components/prices/Prices.php](https://github.com/ktigay/tanuki-test/compare/master...dev#diff-f76c2dfa87569001d029ab92e30f684210ac070b344fd8f23bf57f56af27be3b), в случае если возможно получение из разных источников. Возможно вместо интерфейса реализовал бы абстрактный класс с методом cache() по аналогии с yii\db\Connection::cache(), либо какой-то другой механизм для управления параметрами кэширования.
Так же для кэширования данных добавил в конфиг новый компонент. 

P.S. Наверное добавил бы модель формы, инкапсулировал туда расчет стоимости, валидацию. 

Метод [/basket/calculate](https://github.com/ktigay/tanuki-test/compare/master...dev#diff-26a48bcf26d4d89fbf048d495f7217b5ca2f4a7d4a381ef2889a322a88fad324) принимает данные в виде:
```
{ 
    "data" : {
        "basket": {
            "items":[
                {"id":"1","count":"22"},
                {"id":"2","count":"12"},
                {"id":"3","count":"33"}
            ]
        }
    }
}
```

Возвращает: 
```
{
    "errorCode": null,
    "errorText": null,
    "data": {
        "basket": {
            "items": [
                {
                    "id": 1,
                    "count": 22,
                    "price": 631.62
                },
                {
                    "id": 2,
                    "count": 12,
                    "price": 225.72
                },
                {
                    "id": 3,
                    "count": 33,
                    "price": 667.26
                }
            ],
            "total": 1524.6
        }
    }
}
```